### PR TITLE
SELFIES-TED training code and embedding projection 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,171 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# PyPI configuration file
+.pypirc

--- a/models/selfies_ted/embedding.py
+++ b/models/selfies_ted/embedding.py
@@ -1,0 +1,142 @@
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import os
+
+from models.selfies_ted.load import SELFIES
+from transformers import AutoTokenizer, BartForConditionalGeneration
+from transformers.modeling_outputs import BaseModelOutput
+from huggingface_hub import PyTorchModelHubMixin, snapshot_download
+
+class Projector(nn.Module):
+    def __init__(self, config):
+        super(Projector, self).__init__()
+        self.config = config
+        self.layer1 = nn.Linear(self.config["input_dim"][0]*self.config["input_dim"][1], self.config["hidden_dim"])
+        self.layer2 = nn.Linear(self.config["hidden_dim"], self.config["hidden_dim"])
+        self.layer3 = nn.Linear(self.config["hidden_dim"], self.config["hidden_dim"])
+        self.layer4 = nn.Linear(self.config["hidden_dim"], self.config["output_dim"])
+        self.activation = F.rrelu
+
+    def forward(self, x):
+        x = torch.nn.Flatten()(x)
+        x = self.activation(self.layer1(x))
+        x = self.activation(self.layer2(x))
+        x = self.activation(self.layer3(x))
+        x = self.layer4(x)
+
+        return x
+
+class InverseProjector(nn.Module):
+    def __init__(self, config):
+        super(InverseProjector, self).__init__()
+        self.config = config
+        self.layer1 = nn.Linear(self.config["input_dim"], self.config["hidden_dim"])
+        self.layer2 = nn.Linear(self.config["hidden_dim"], self.config["hidden_dim"])
+        self.layer3 = nn.Linear(self.config["hidden_dim"], self.config["hidden_dim"])
+        self.layer4 = nn.Linear(self.config["hidden_dim"], self.config["output_dim"][0]*self.config["output_dim"][1])
+        self.activation = F.rrelu
+
+    def forward(self, x):
+        x = self.activation(self.layer1(x))
+        x = self.activation(self.layer2(x))
+        x = self.activation(self.layer3(x))
+        x = self.layer4(x)
+        x = x.reshape(len(x), self.config["output_dim"][0], self.config["output_dim"][1])
+        if x.shape[2] == 1:
+            x = x.reshape(x.shape[0], x.shape[1])
+        return x
+
+'''
+SELFIES-TED model with projections to a single 128-dimensional latent vector for a SELFIES string
+'''    
+class SELFIESForEmbeddingExploration(SELFIES, PyTorchModelHubMixin):
+    
+    def __init__(self) -> None:
+        super().__init__()
+        config_proj = {"input_dim": [64, 256],
+                         "hidden_dim":  512,
+                         "output_dim":128}
+        self.projector = Projector(config_proj)
+        
+        config_invproj = {"input_dim": 128,
+                            "hidden_dim": 512,
+                            "output_dim": [64, 256]}
+        self.invprojector = InverseProjector(config_invproj)
+
+    def load(self, checkpoint="ibm/materials.selfies-ted2m"):
+        """
+            inputs :
+                   checkpoint - HuggingFace repo or path to directory containing checkpoints
+        """
+
+        self.tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+        self.lm = BartForConditionalGeneration.from_pretrained(checkpoint)
+        self.model = self.lm.model
+
+    def load_projectors(self, checkpoint_dir: str) -> None:
+        self.projector.load_state_dict(torch.load(os.path.join(checkpoint_dir, "projector_2023-05-25.pth")))
+        self.invprojector.load_state_dict(torch.load(os.path.join(checkpoint_dir, "invprojector_2023-05-25.pth")))
+
+    @classmethod
+    def _from_pretrained(
+        cls,
+        *,
+        model_id: str,
+        revision: Optional[str],
+        cache_dir: Optional[Union[str, Path]],
+        force_download: bool,
+        proxies: Optional[Dict],
+        resume_download: Optional[bool],
+        local_files_only: bool,
+        token: Union[str, bool, None],
+        map_location: str = "cpu",
+        strict: bool = False,
+        **model_kwargs,
+    ):
+        """Load Pytorch pretrained weights and return the loaded model."""
+        model = cls(**model_kwargs)
+       
+        if os.path.isdir(model_id):
+            print("Loading weights from local directory")
+            model.load(model_id)
+            model.load_projectors(model_id)
+        else:
+            model_dir = snapshot_download(
+                repo_id=model_id,
+                revision=revision,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                proxies=proxies,
+                resume_download=resume_download,
+                token=token,
+                local_files_only=local_files_only,
+            )
+            model.load(model_dir)
+            model.load_projectors(model_dir)
+           
+        return model
+
+    def hidden_state_to_latent_vector(self, hidden_state: torch.Tensor) -> torch.Tensor:
+        return self.projector(hidden_state).cpu().detach()
+    
+    def latent_vector_to_hidden_state(self, latent_vector: torch.Tensor) -> torch.Tensor:
+        return self.invprojector(latent_vector).cpu().detach()
+    
+    def get_encoder_last_hidden_state(self, selfies):
+        encoding = self.tokenizer(selfies, return_tensors='pt', max_length=64, truncation=True, padding='max_length')
+        input_ids = encoding['input_ids']
+        outputs = self.model.encoder(input_ids=input_ids)
+        return outputs.last_hidden_state
+    
+    def get_latent_vector(self, selfies: List[str]) -> torch.Tensor:
+        return self.hidden_state_to_latent_vector(self.get_encoder_last_hidden_state(selfies))
+
+    def decode(self, embedding):
+        hidden_state = self.latent_vector_to_hidden_state(embedding)
+        encoder_outputs = BaseModelOutput(hidden_state)
+        decoder_output = self.lm.generate(encoder_outputs=encoder_outputs, max_new_tokens=64, do_sample=True,  top_k=1, top_p=0.95, num_return_sequences=1)
+        return self.tokenizer.batch_decode(decoder_output, skip_special_tokens=True)
+        

--- a/models/selfies_ted/requirements.txt
+++ b/models/selfies_ted/requirements.txt
@@ -10,3 +10,5 @@ requests>=2.31.0
 urllib3>=2.0.7
 aiohttp>=3.9.0
 zipp>=3.17.0
+feather-format>=0.4.1
+accelerate>=0.26.0

--- a/models/selfies_ted/requirements.txt
+++ b/models/selfies_ted/requirements.txt
@@ -12,3 +12,4 @@ aiohttp>=3.9.0
 zipp>=3.17.0
 feather-format>=0.4.1
 accelerate==0.26.0
+rdkit>=2024.3.5

--- a/models/selfies_ted/requirements.txt
+++ b/models/selfies_ted/requirements.txt
@@ -1,5 +1,5 @@
 torch>=2.1.0
-transformers>=4.38
+transformers==4.38.1
 numpy>=1.26.1
 datasets>=2.13.1
 evaluate>=0.4.0
@@ -11,4 +11,4 @@ urllib3>=2.0.7
 aiohttp>=3.9.0
 zipp>=3.17.0
 feather-format>=0.4.1
-accelerate>=0.26.0
+accelerate==0.26.0

--- a/models/selfies_ted/train.py
+++ b/models/selfies_ted/train.py
@@ -1,0 +1,148 @@
+from transformers import BartConfig
+from transformers import BartForConditionalGeneration
+from transformers import TrainingArguments, Trainer
+from transformers import AutoTokenizer
+from transformers import DataCollatorForSeq2Seq
+import numpy as np
+import torch, argparse
+import evaluate
+import feather
+from datasets import Dataset, load_dataset
+
+# Train SELFIES-TED(small)
+
+def train(training_dataset_path: str, base_model_path: str, epochs: int):
+
+    if training_dataset_path==None:
+        training_dataset_path = "./H22M400.ftr"
+
+    print("Training dataset: ", training_dataset_path)
+    if training_dataset_path.endswith(".ftr"):
+        dataset = Dataset.from_pandas(feather.read_dataframe(training_dataset_path))
+    else:
+        dataset = load_dataset("csv", data_files=training_dataset_path)["train"]
+
+    print("Number of samples : ", len(dataset))
+
+    if base_model_path==None:
+        print("Training from scratch")
+        base_model_path = "ibm/materials.selfies-ted2m"
+        tokenizer = AutoTokenizer.from_pretrained(base_model_path)
+        token2idx = tokenizer.get_vocab()
+        config = BartConfig()
+        config.vocab_size = len(token2idx)
+        config.pad_token_id = token2idx["[PAD]"]
+        config.eos_token_id = token2idx["[SEP]"]
+        config.bos_token_id = token2idx["[CLS]"]
+
+        ### config changes (2.2M param)
+
+        config.encoder_ffn_dim = 256
+        config.decoder_ffn_dim = 256
+
+        config.encoder_attention_heads = 4
+        config.decoder_attention_heads = 4
+
+        config.encoder_layers = 2
+        config.decoder_layers = 2
+
+        config.num_hidden_layers = 6
+        config.max_position_embeddings = 128
+        config.dmodel = 256
+        config.d_model = 256
+
+        model = BartForConditionalGeneration(config)
+    else:
+        print("Loading base model ", base_model_path)
+        tokenizer = AutoTokenizer.from_pretrained(base_model_path)
+        model = BartForConditionalGeneration.from_pretrained(base_model_path)    
+    
+
+    def preprocess_function(examples):
+        return tokenizer([x for x in examples["SELFIES"]], return_tensors='pt', max_length=128, truncation=True,
+                         padding='max_length')
+
+    tokenized_inputs = dataset.map(
+        preprocess_function,
+        batched=True,
+        num_proc=16
+    )
+
+    device = torch.device('cuda') if torch.cuda.is_available() else torch.device('cpu')
+
+    print("Total parameters : ", sum(p.numel() for p in model.parameters()))
+
+    def make_labels(examples):
+        del examples["token_type_ids"]
+        examples["labels"] = examples["input_ids"].copy()
+
+
+        rand = torch.rand(torch.Tensor(examples["input_ids"]).shape)
+        mask = (rand < 0.15) * (torch.Tensor(examples["input_ids"]) != tokenizer.pad_token_id) * (
+                    torch.Tensor(examples["input_ids"]) != tokenizer.cls_token_id) * (
+                       torch.Tensor(examples["input_ids"]) != tokenizer.sep_token_id)
+
+        masked_input_ids = torch.where(mask, tokenizer.mask_token_id, torch.Tensor(examples["input_ids"]))
+
+        examples["input_ids"] = masked_input_ids.tolist()
+
+        return examples
+
+    lm_dataset = tokenized_inputs.map(make_labels, batched=True, num_proc=16)
+
+    data_collator = DataCollatorForSeq2Seq(tokenizer=tokenizer, model=model)
+
+    metric = evaluate.load("accuracy")
+
+    def compute_metrics(eval_pred):
+        logits, labels = eval_pred
+        predictions = np.argmax(logits, axis=-1)
+
+        indices = [[i for i, x in enumerate(labels[row]) if x != -100] for row in range(len(labels))]
+
+        labels = [labels[row][indices[row]] for row in range(len(labels))]
+        labels = [item for sublist in labels for item in sublist]
+
+        predictions = [predictions[row][indices[row]] for row in range(len(predictions))]
+        predictions = [item for sublist in predictions for item in sublist]
+
+        results = metric.compute(predictions=predictions, references=labels)
+        results["eval_accuracy"] = results["accuracy"]
+        print(results)
+        results.pop("accuracy")
+
+        return results
+
+    training_args = TrainingArguments(
+        output_dir="checkpoints",
+        evaluation_strategy="no",
+        num_train_epochs=epochs,
+        per_device_train_batch_size=256,
+        logging_strategy="epoch",
+        save_strategy="epoch",
+        do_eval=False
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        tokenizer=tokenizer,
+        train_dataset=lm_dataset,
+        data_collator=data_collator,
+        compute_metrics=compute_metrics
+    )
+
+    trainer.train()
+    print("Training Completed! ")
+
+    return
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='SELFIES-TED training')
+    parser.add_argument('-f', '--file', required=False, type=str)
+    parser.add_argument('-b', '--base-model', required=False, type=str)
+    parser.add_argument('-e', '--epochs', required=False, type=int, default=1)
+    args = parser.parse_args()
+    print(args)
+    train(args.file, args.base_model, args.epochs)
+    print("Completed!")


### PR DESCRIPTION
This PR adds example training code for SELFIES-TED, and embedding projection. 

`embedding.py` contains a new model subclass `SELFIESForEmbeddingExploration`.  This provides functions to convert the per-token last hidden state tensor from the BART encoder and a single 128-dimensiona vector for the whole SELFIES sequence. It depends on projector checkpoints, which are available as part of the [selfies-ted2m model variant on HuggingFace](https://huggingface.co/ibm-research/materials.selfies-ted2m). 

I've also included some small fixes:
- Pin transformers at version 4.38.1 as this improvees generation performance for the model
- Add missing RDKit requirement for example notebook
- Include a .gitignore for the repo