### PR TITLE
Use `mordredcommunity` instead of `mordred`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ zipp>=3.19.1
 umap-learn
 torch-optimizer
 tqdm>=4.66.4
-mordred
+mordredcommunity
 triton==2.2.0
 ase==3.24.0
 torch_scatter


### PR DESCRIPTION
Hi - great work with this model!

I've been maintaining a community-driven fork of `mordred` called [`mordredcommunity`](https://github.com/JacksonBurns/mordred-community) that fixes some bugs but also adds support for all current python version (3.9-3.13). You may consider switching to it, as I have in this PR. No code changes are required - the pypi package is called `mordredcommunity` but the resulting package on import is called `mordred` still.